### PR TITLE
add serial runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ utest 是 RT-Thread 自带的单元测试框架，本项目为其提供自动化
 
 ## how
 
-### STEP1 准备 BSP
+### 1. 基于QEMU平台运行自动化测试
+
+#### STEP1 准备 BSP
 
 准备一个可以集成测试用例的 BSP 工程，支持 Scons 构建，并保证可以构建成功，并生成 bin 或 elf。
 
-> 注意：目前测试机器人暂时 **只支持** QEMU ，建议将测试用例支持 QEMU
-
-### STEP2 准备运行环境
+#### STEP2 准备运行环境
 
 运行环境需要支持以下条件：
 
@@ -34,7 +34,7 @@ utest 是 RT-Thread 自带的单元测试框架，本项目为其提供自动化
 
 项目已提供好其配置模板，详见根目录对应文件及文件夹
 
-### STEP3 运行测试机器人（以 QEMU 为例）
+#### STEP3 运行测试机器人（以 QEMU 为例）
 
 QEMU 测试机器人代码位于 `qemu_runner.py` ，help 信息如下：
 
@@ -70,3 +70,49 @@ WARNING: Image format was not specified for 'D:/Program/RTT/rt-thread/bsp/qemu-v
 D:\Program\Python\UtestQemuRunner>
 ```
 
+### 2. 基于真实硬件平台运行自动化测试
+
+#### STEP1 准备 BSP
+
+准备一个可以集成测试用例的 BSP 工程，支持 Scons 构建，并保证可以构建成功，并生成 bin 或 elf。
+
+#### STEP2 准备运行环境
+
+运行环境需要支持以下条件：
+
+- python3
+- scons
+- pyserial
+- pyserial-asyncio
+
+>  注意：目前不支持通过 CI 环境执行。
+
+#### STEP3 运行测试机器人（以 Serial 为例）
+
+Serial 测试机器人代码位于 `serial _runner.py` ，help 信息如下：
+
+```shell
+python .\serial_runner.py --help
+usage: serial_runner.py [-h] [--port port] [--baudrate bps] [--delay seconds]
+
+serial runner for RT-Thread utest
+
+options:
+  -h, --help       show this help message and exit
+  --port port      port for serial
+  --baudrate bps   baudrate for serial
+  --delay seconds  delay some seconds for serial running finish
+```
+
+先将 BSP 编译出来 elf 烧录到开发板上，运行起来。
+
+然后传入开发板对应的串口号和波特率即可启动机器人，以下是示例：
+
+```shell
+python.exe .\serial_runner.py --port=com16 --baudrate=115200
+2023-07-04 12:04:25,289 asyncio DEBUG: Using proactor: IocpProactor
+2023-07-04 12:04:31,419 utest DEBUG: Get a testcase: testcases.utest.pass_tc, timeout: 10
+2023-07-04 12:04:31,420 utest INFO: Start test: testcases.utest.pass_tc
+2023-07-04 12:04:32,552 utest INFO: Test passed
+2023-07-04 12:04:32,552 serial_runner INFO: serial runner destroy
+```

--- a/serial_runner.py
+++ b/serial_runner.py
@@ -1,0 +1,151 @@
+#!/user/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Armink, <armink.ztl@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Change Logs:
+# Date           Author       Notes
+# 2020-01-26     armink       the first version
+# 2023-07-03     flybreak     support serial port
+#
+import argparse
+import os
+import sys
+import threading
+import logging
+import time
+import asyncio
+from serial_asyncio import open_serial_connection
+
+from utest import Utest
+
+LOG_LVL = logging.DEBUG
+LOG_TAG = 'serial_runner'
+logger = logging.getLogger(LOG_TAG)
+
+class SerialRunner:
+    def __init__(self, port, baudrate, delay):
+        logging.basicConfig(level=LOG_LVL, format='%(asctime)s %(name)s %(levelname)s: %(message)s', datefmt=None)
+        self.port = port
+        self.baudrate = baudrate
+        self.delay = delay
+        self.env_version = ''
+        self.sub_proc = None
+        self.reader = None
+        self.writer = None
+        self.log_recorder = None
+        self.logs = []
+        self.logs_lock = threading.Lock()
+        self.is_executing = False
+
+    def run(self):
+
+        event = threading.Event()
+
+        # RT-Thread console log recorder with serial process
+        def log_recorder_entry():
+            async def run():
+                reader, writer = await open_serial_connection(url=self.port, baudrate=self.baudrate)
+                self.reader = reader
+                self.writer = writer
+                with open('rtt_console.log', 'w') as log_file:
+                    while True:
+                        line = await self.reader.readline()
+                        if line:
+                            line = str(line, encoding="utf8").replace('\n', '').replace('\r', '')
+                            log_file.write(line + '\n')
+                            log_file.flush()
+                            self.logs_lock.acquire()
+                            self.logs.append(line)
+                            self.logs_lock.release()
+                            if self.is_executing and line.find('[ utest    ] finished') != -1:
+                                event.set()
+            loop =  asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(run())
+
+        self.log_recorder = threading.Thread(target=log_recorder_entry)
+        self.log_recorder.daemon = True
+        self.log_recorder.start()
+
+        time.sleep(0.1)
+        if self.writer == None:
+            logger.error("Utest init failed!")
+            return False
+
+        def exec_utest_cmd(name, timeout):
+            self.logs_lock.acquire()
+            self.logs.clear()
+            self.logs_lock.release()
+            self.is_executing = True
+
+            # send command to serial
+            cmb_str = name + '\n'
+            if self.writer:
+                self.writer.write(bytes(cmb_str, encoding='utf8'))
+            else:
+                self.is_executing = False
+                return False, []
+
+            # wait command execute finish
+            event.clear()
+            signaled = event.wait(timeout=timeout)
+            self.is_executing = False
+
+            self.logs_lock.acquire()
+            logs = self.logs
+            self.logs_lock.release()
+            if logs == []:
+                logger.error("Command exec failed!")
+            return signaled, logs
+
+        time.sleep(self.delay)
+        utest = Utest(exec_utest_cmd)
+        if utest.init_result == False:
+            logger.error("Utest init failed!")
+            self.destroy()
+            return False
+
+        success = utest.test_all()
+        self.destroy()
+
+        return success
+
+    def destroy(self):
+        logger.info("serial runner destroy")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='serial runner for RT-Thread utest', prog=os.path.basename(sys.argv[0]))
+
+    parser.add_argument('--port',
+                        metavar='port',
+                        help='port for serial',
+                        default="com16",
+                        type=str,
+                        required=False)
+
+    parser.add_argument('--baudrate',
+                        metavar='bps',
+                        help='baudrate for serial',
+                        default=115200,
+                        type=int,
+                        required=False)
+    
+    parser.add_argument('--delay',
+                        metavar='seconds',
+                        help='delay some seconds for serial running finish',
+                        default=5,
+                        type=int,
+                        required=False)
+
+    args = parser.parse_args()
+    runner = SerialRunner(args.port, args.baudrate, args.delay)
+    if not runner.run():
+        sys.exit(-1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
支持通过usb串口的通道进行自动测试。

```
PS E:\workspace\autotest\UtestRunner> python.exe .\serial_runner.py --port=com31 --baudrate=115200 --delay=1
2023-07-03 22:46:12,125 asyncio DEBUG: Using proactor: IocpProactor
2023-07-03 22:46:14,250 utest DEBUG: Get a testcase: testcases.kernel.mem_tc, timeout: 20
2023-07-03 22:46:14,251 utest DEBUG: Get a testcase: testcases.utest.pass_tc, timeout: 10
2023-07-03 22:46:14,251 utest INFO: Start test: testcases.kernel.mem_tc
2023-07-03 22:46:26,245 utest INFO: Test passed
2023-07-03 22:46:26,246 utest INFO: Start test: testcases.utest.pass_tc
2023-07-03 22:46:27,373 utest INFO: Test passed
2023-07-03 22:46:27,374 serial_runner INFO: serial runner destroy
```